### PR TITLE
Fix websockets url

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const STREAM_TOKEN = '<INSERT-API-ACCESS-TOKEN-HERE>'
+const API_TOKEN = '<INSERT-LEGACY-API-KEY-HERE>'
 const io = require('socket.io-client')
 const request = require('request')
 
@@ -13,13 +13,13 @@ function logResult(eventName) {
 console.log('Requesting socket token')
 let timestamp = Date.now()
 request({
-  url: `https://streamlabs.com/service/get-socket-token?token=${STREAM_TOKEN}&ts=${timestamp}`,
+  url: `https://streamlabs.com/service/get-socket-token?token=${API_TOKEN}&ts=${timestamp}`,
   json: true
 }, (err, res, data) => {
   let token = data.token
 
   console.log('Connecting to websocket')
-  let twitchAlerts = io('http://io.streamlabs.com', {query: {token}})
+  let twitchAlerts = io(`https://aws-io.streamlabs.com?token=${token}`)
 
   twitchAlerts.on('connect', logResult('connect'))
   twitchAlerts.on('connect_error', logResult('connect_error'))


### PR DESCRIPTION
Also, make it more clear that the socket token must be fetched using the app's legacy API key.